### PR TITLE
Use wildcard for exercise feedback artifacts

### DIFF
--- a/.github/workflows/exercise-feedback.yml
+++ b/.github/workflows/exercise-feedback.yml
@@ -48,5 +48,5 @@ jobs:
       - name: Upload feedback
         uses: actions/upload-artifact@v4
         with:
-          name: feedback-log.txt
-          path: ./grading/feedback-log.txt
+          name: exercise-feedback
+          path: ./grading/feedback-ex?.txt


### PR DESCRIPTION
In this state, all logs are added in a zip file as artifact:
https://github.com/jvalue/made-template/actions/runs/10942758715